### PR TITLE
Scaffold monorepo with mobile and dashboard apps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint", "react", "react-hooks"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "overrides": [
+    {
+      "files": ["apps/dashboard/**/*"],
+      "extends": ["next/core-web-vitals"]
+    }
+  ],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  },
+  "ignorePatterns": ["node_modules", "dist", "build", "*.config.js"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+node_modules
+.pnpm-store
+.idea
+.vscode
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+dist
+build
+.next
+.expo
+.expo-shared
+.DS_Store
+coverage

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": true,
+  "printWidth": 100
+}

--- a/README.md
+++ b/README.md
@@ -17,3 +17,31 @@
 
 ## 📦 Structure
 
+This repository is organized as a PNPM-powered monorepo with dedicated apps for mobile and web, plus shared packages for UI, data models, and API access.
+
+```
+.
+├── apps
+│   ├── dashboard   # Next.js vendor console
+│   └── mobile      # Expo React Native customer app
+├── packages
+│   ├── api-client  # Typed API helpers for menus, loyalty, and orders
+│   ├── models      # Shared data contracts
+│   └── ui          # Reusable UI building blocks for the dashboard
+├── tsconfig.json   # Shared compiler settings and path aliases
+├── pnpm-workspace.yaml
+└── package.json
+```
+
+### Quickstart
+
+1. Install dependencies with `pnpm install`.
+2. Run `pnpm dev:mobile` to start the Expo dev server.
+3. Run `pnpm dev:dashboard` to start the Next.js dashboard.
+
+### What’s included
+
+- **Typed data models** for vendors, menu items, loyalty, and orders.
+- **API client stubs** for fetching featured vendors, menus, loyalty snapshots, and recent orders.
+- **Shared UI components** for dashboard sections and stats.
+- **Placeholder screens** in both apps aligned to the ordering, loyalty, and vendor management flows described above.

--- a/apps/dashboard/next-env.d.ts
+++ b/apps/dashboard/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/dashboard/next.config.js
+++ b/apps/dashboard/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: ['@countrtop/ui', '@countrtop/models', '@countrtop/api-client']
+};
+
+module.exports = nextConfig;

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@countrtop/dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@countrtop/api-client": "workspace:*",
+    "@countrtop/models": "workspace:*",
+    "@countrtop/ui": "workspace:*",
+    "next": "14.2.6",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/apps/dashboard/pages/index.tsx
+++ b/apps/dashboard/pages/index.tsx
@@ -1,0 +1,68 @@
+import Head from 'next/head';
+import React from 'react';
+import { LoyaltySnapshot, OrderSummary, VendorProfile } from '@countrtop/models';
+import { Section, StatCard } from '@countrtop/ui';
+
+const vendors: VendorProfile[] = [
+  { id: 'v1', name: 'Hilltop Tacos', cuisine: 'Mexican', location: 'Mission Bay' },
+  { id: 'v2', name: 'Sunset Coffee Cart', cuisine: 'Cafe', location: 'Sunset Park' }
+];
+
+const loyalty: LoyaltySnapshot = {
+  points: 420,
+  tier: 'gold',
+  nextRewardAt: 500
+};
+
+const recentOrders: OrderSummary[] = [
+  { id: 'o1', status: 'pending', total: 120, etaMinutes: 12 },
+  { id: 'o2', status: 'ready', total: 84.5, etaMinutes: 3 }
+];
+
+export default function Dashboard() {
+  return (
+    <>
+      <Head>
+        <title>CountrTop Dashboard</title>
+      </Head>
+      <main style={{ padding: '32px', fontFamily: 'Inter, sans-serif' }}>
+        <h1 style={{ marginBottom: 8 }}>CountrTop Vendor Console</h1>
+        <p style={{ color: '#6b7280', marginBottom: 24 }}>
+          Track orders, loyalty performance, and keep menus fresh for your customers.
+        </p>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 16 }}>
+          <StatCard label="Active orders" value={recentOrders.length} helperText="Across all trucks" />
+          <StatCard label="Loyalty points today" value={loyalty.points} helperText="Earned by fans" />
+          <StatCard label="Vendors live" value={vendors.length} helperText="Linked to your org" />
+        </div>
+
+        <Section title="Live orders" subtitle="Fulfillment">
+          <ul style={{ padding: 0, margin: 0, listStyle: 'none' }}>
+            {recentOrders.map((order) => (
+              <li key={order.id} style={{ marginBottom: 12 }}>
+                <div style={{ fontWeight: 600 }}>Order {order.id}</div>
+                <div style={{ color: '#6b7280' }}>
+                  Status: {order.status} • Total ${order.total.toFixed(2)} • ETA {order.etaMinutes}m
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Section>
+
+        <Section title="Vendor lineup" subtitle="Fleet">
+          <ul style={{ padding: 0, margin: 0, listStyle: 'none' }}>
+            {vendors.map((vendor) => (
+              <li key={vendor.id} style={{ marginBottom: 12 }}>
+                <div style={{ fontWeight: 600 }}>{vendor.name}</div>
+                <div style={{ color: '#6b7280' }}>
+                  {vendor.cuisine} • {vendor.location}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      </main>
+    </>
+  );
+}

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "noEmit": true,
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { ScrollView, SafeAreaView, Text, View, StyleSheet } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import { LoyaltySnapshot, MenuItem, OrderSummary, VendorProfile } from '@countrtop/models';
+
+const featuredVendors: VendorProfile[] = [
+  { id: 'v1', name: 'Hilltop Tacos', cuisine: 'Mexican', location: 'Mission Bay' },
+  { id: 'v2', name: 'Sunset Coffee Cart', cuisine: 'Cafe', location: 'Sunset Park' }
+];
+
+const sampleMenu: MenuItem[] = [
+  { id: 'm1', name: 'Loaded Nachos', price: 12, isAvailable: true },
+  { id: 'm2', name: 'Horchata Latte', price: 6, isAvailable: false }
+];
+
+const loyalty: LoyaltySnapshot = {
+  points: 280,
+  tier: 'silver',
+  nextRewardAt: 300
+};
+
+const recentOrders: OrderSummary[] = [
+  { id: 'o1', status: 'preparing', total: 24.5, etaMinutes: 8 },
+  { id: 'o2', status: 'completed', total: 16 }
+];
+
+export default function App() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <StatusBar style="dark" />
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <Text style={styles.heading}>CountrTop</Text>
+        <Text style={styles.subtitle}>Order ahead, earn rewards, and track your food truck favorites.</Text>
+
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Featured vendors</Text>
+          {featuredVendors.map((vendor) => (
+            <View key={vendor.id} style={styles.row}>
+              <Text style={styles.rowTitle}>{vendor.name}</Text>
+              <Text style={styles.rowSubtitle}>
+                {vendor.cuisine} • {vendor.location}
+              </Text>
+            </View>
+          ))}
+        </View>
+
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Quick order</Text>
+          {sampleMenu.map((item) => (
+            <View key={item.id} style={styles.row}>
+              <Text style={styles.rowTitle}>{item.name}</Text>
+              <Text style={styles.rowSubtitle}>${item.price.toFixed(2)}</Text>
+              <Text style={[styles.badge, !item.isAvailable && styles.badgeMuted]}>
+                {item.isAvailable ? 'Available' : 'Sold out'}
+              </Text>
+            </View>
+          ))}
+        </View>
+
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Loyalty</Text>
+          <Text style={styles.rowTitle}>{loyalty.tier.toUpperCase()} tier</Text>
+          <Text style={styles.rowSubtitle}>
+            {loyalty.points} pts • Next reward at {loyalty.nextRewardAt} pts
+          </Text>
+        </View>
+
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>Order status</Text>
+          {recentOrders.map((order) => (
+            <View key={order.id} style={styles.row}>
+              <Text style={styles.rowTitle}>Order {order.id}</Text>
+              <Text style={styles.rowSubtitle}>{order.status}</Text>
+              {order.etaMinutes ? (
+                <Text style={styles.badge}>ETA {order.etaMinutes}m</Text>
+              ) : (
+                <Text style={[styles.badge, styles.badgeMuted]}>Completed</Text>
+              )}
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f7f7f7'
+  },
+  scrollContent: {
+    padding: 20,
+    gap: 12
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: '700'
+  },
+  subtitle: {
+    color: '#6b7280',
+    marginBottom: 8
+  },
+  card: {
+    backgroundColor: '#fff',
+    padding: 16,
+    borderRadius: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 }
+  },
+  cardTitle: {
+    fontWeight: '600',
+    fontSize: 16,
+    marginBottom: 8
+  },
+  row: {
+    marginBottom: 8
+  },
+  rowTitle: {
+    fontSize: 15,
+    fontWeight: '600'
+  },
+  rowSubtitle: {
+    color: '#6b7280'
+  },
+  badge: {
+    alignSelf: 'flex-start',
+    marginTop: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 999,
+    backgroundColor: '#ecfeff',
+    color: '#0ea5e9'
+  },
+  badgeMuted: {
+    backgroundColor: '#f3f4f6',
+    color: '#6b7280'
+  }
+});

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,0 +1,11 @@
+{
+  "expo": {
+    "name": "CountrTop Mobile",
+    "slug": "countrtop-mobile",
+    "version": "0.1.0",
+    "orientation": "portrait",
+    "sdkVersion": "51.0.0",
+    "platforms": ["ios", "android"],
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo']
+  };
+};

--- a/apps/mobile/expo-env.d.ts
+++ b/apps/mobile/expo-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="expo" />

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,0 +1,15 @@
+const { getDefaultConfig } = require('@expo/metro-config');
+const path = require('path');
+
+const projectRoot = __dirname;
+const workspaceRoot = path.resolve(projectRoot, '../..');
+
+const config = getDefaultConfig(projectRoot);
+config.watchFolders = [workspaceRoot];
+config.resolver.nodeModulesPaths = [
+  path.resolve(projectRoot, 'node_modules'),
+  path.resolve(workspaceRoot, 'node_modules')
+];
+config.resolver.sourceExts = [...config.resolver.sourceExts, 'cjs'];
+
+module.exports = config;

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@countrtop/mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "expo/entry",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "lint": "eslint 'app/**/*.{ts,tsx}'"
+  },
+  "dependencies": {
+    "@countrtop/api-client": "workspace:*",
+    "@countrtop/models": "workspace:*",
+    "expo": "~51.0.0",
+    "expo-status-bar": "~1.12.0",
+    "react": "18.3.1",
+    "react-native": "0.74.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.5",
+    "@types/react-native": "^0.73.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-native"
+  },
+  "include": ["app", "App.tsx", "expo-env.d.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "countrtop-monorepo",
+  "version": "0.1.0",
+  "private": true,
+  "packageManager": "pnpm@9.10.0",
+  "scripts": {
+    "dev:mobile": "pnpm --filter @countrtop/mobile start",
+    "dev:dashboard": "pnpm --filter @countrtop/dashboard dev",
+    "build": "pnpm -r run build",
+    "lint": "pnpm -r run lint",
+    "format": "prettier --write ."
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.9",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^7.16.1",
+    "@typescript-eslint/parser": "^7.16.1",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.6",
+    "eslint-plugin-react": "^7.35.0",
+    "eslint-plugin-react-hooks": "^5.1.0-rc.0",
+    "prettier": "^3.3.3",
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@countrtop/api-client",
+  "version": "0.1.0",
+  "private": false,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "source": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --emitDeclarationOnly",
+    "lint": "eslint 'src/**/*.{ts,tsx}'"
+  },
+  "dependencies": {
+    "@countrtop/models": "workspace:*"
+  }
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,0 +1,52 @@
+import { LoyaltySnapshot, MenuItem, OrderSummary, VendorProfile } from '@countrtop/models';
+
+type ApiConfig = {
+  baseUrl?: string;
+};
+
+const defaultConfig: Required<ApiConfig> = {
+  baseUrl: 'https://api.countrtop.local'
+};
+
+const createUrl = (path: string, baseUrl: string) => `${baseUrl}${path}`;
+
+export const fetchFeaturedVendors = async (
+  config: ApiConfig = defaultConfig
+): Promise<VendorProfile[]> => {
+  const response = await fetch(createUrl('/vendors/featured', config.baseUrl ?? defaultConfig.baseUrl));
+  if (!response.ok) throw new Error('Failed to load vendors');
+  return response.json();
+};
+
+export const fetchMenu = async (
+  vendorId: string,
+  config: ApiConfig = defaultConfig
+): Promise<MenuItem[]> => {
+  const response = await fetch(
+    createUrl(`/vendors/${vendorId}/menu`, config.baseUrl ?? defaultConfig.baseUrl)
+  );
+  if (!response.ok) throw new Error('Failed to load menu');
+  return response.json();
+};
+
+export const fetchLoyalty = async (
+  userId: string,
+  config: ApiConfig = defaultConfig
+): Promise<LoyaltySnapshot> => {
+  const response = await fetch(
+    createUrl(`/users/${userId}/loyalty`, config.baseUrl ?? defaultConfig.baseUrl)
+  );
+  if (!response.ok) throw new Error('Failed to load loyalty');
+  return response.json();
+};
+
+export const fetchRecentOrders = async (
+  vendorId: string,
+  config: ApiConfig = defaultConfig
+): Promise<OrderSummary[]> => {
+  const response = await fetch(
+    createUrl(`/vendors/${vendorId}/orders/recent`, config.baseUrl ?? defaultConfig.baseUrl)
+  );
+  if (!response.ok) throw new Error('Failed to load orders');
+  return response.json();
+};

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@countrtop/models",
+  "version": "0.1.0",
+  "private": false,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "source": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --emitDeclarationOnly",
+    "lint": "eslint 'src/**/*.{ts,tsx}'"
+  }
+}

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -1,0 +1,28 @@
+export type MenuItem = {
+  id: string;
+  name: string;
+  description?: string;
+  price: number;
+  isAvailable: boolean;
+};
+
+export type VendorProfile = {
+  id: string;
+  name: string;
+  cuisine: string;
+  location: string;
+  heroImage?: string;
+};
+
+export type LoyaltySnapshot = {
+  points: number;
+  tier: 'bronze' | 'silver' | 'gold';
+  nextRewardAt: number;
+};
+
+export type OrderSummary = {
+  id: string;
+  status: 'pending' | 'preparing' | 'ready' | 'completed';
+  total: number;
+  etaMinutes?: number;
+};

--- a/packages/models/tsconfig.json
+++ b/packages/models/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@countrtop/ui",
+  "version": "0.1.0",
+  "private": false,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "source": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --emitDeclarationOnly",
+    "lint": "eslint 'src/**/*.{ts,tsx}'"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "react": "^18.3.1"
+  }
+}

--- a/packages/ui/src/Section.tsx
+++ b/packages/ui/src/Section.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+type SectionProps = {
+  title: string;
+  subtitle?: string;
+  children?: React.ReactNode;
+};
+
+export const Section: React.FC<SectionProps> = ({ title, subtitle, children }) => (
+  <section style={{ border: '1px solid #e5e7eb', borderRadius: 12, padding: 16, marginBottom: 16 }}>
+    <header style={{ marginBottom: 12 }}>
+      <p style={{ fontSize: 12, color: '#6b7280', margin: 0, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+        {subtitle}
+      </p>
+      <h2 style={{ margin: 0 }}>{title}</h2>
+    </header>
+    {children}
+  </section>
+);

--- a/packages/ui/src/StatCard.tsx
+++ b/packages/ui/src/StatCard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+type StatCardProps = {
+  label: string;
+  value: string | number;
+  helperText?: string;
+};
+
+export const StatCard: React.FC<StatCardProps> = ({ label, value, helperText }) => (
+  <div
+    style={{
+      border: '1px solid #e5e7eb',
+      borderRadius: 12,
+      padding: 16,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 4,
+      background: '#f9fafb'
+    }}
+  >
+    <span style={{ color: '#6b7280', fontSize: 12 }}>{label}</span>
+    <strong style={{ fontSize: 22 }}>{value}</strong>
+    {helperText ? <span style={{ color: '#9ca3af', fontSize: 12 }}>{helperText}</span> : null}
+  </div>
+);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,2 @@
+export { Section } from './Section';
+export { StatCard } from './StatCard';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "strict": true,
+    "allowJs": false,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@countrtop/ui": ["packages/ui/src"],
+      "@countrtop/ui/*": ["packages/ui/src/*"],
+      "@countrtop/models": ["packages/models/src"],
+      "@countrtop/models/*": ["packages/models/src/*"],
+      "@countrtop/api-client": ["packages/api-client/src"],
+      "@countrtop/api-client/*": ["packages/api-client/src/*"]
+    }
+  },
+  "include": ["packages", "apps"],
+  "exclude": ["node_modules", "dist", "build"]
+}


### PR DESCRIPTION
## Summary
- set up PNPM workspace with shared TypeScript config, linting, and formatting defaults
- add Expo mobile app skeleton with placeholder ordering, loyalty, and vendor sections
- add Next.js dashboard page plus shared UI, models, and API client packages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694231e17484832f9de1fe52d9772ff2)