### PR TITLE
Add shared data package with models and Supabase client

### DIFF
--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@countrtop/data",
+  "version": "0.1.0",
+  "private": false,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "source": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --emitDeclarationOnly",
+    "lint": "eslint 'src/**/*.{ts,tsx}'"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.6"
+  }
+}

--- a/packages/data/src/dataClient.ts
+++ b/packages/data/src/dataClient.ts
@@ -1,0 +1,32 @@
+import { MenuItem, Order, OrderStatus, RewardActivity, User, VendorSettings } from './models';
+
+export type Subscription = {
+  unsubscribe: () => Promise<void> | void;
+};
+
+export type CreateOrderInput = Omit<Order, 'id' | 'createdAt' | 'updatedAt' | 'status'> &
+  Partial<Pick<Order, 'id' | 'createdAt' | 'updatedAt' | 'status'>>;
+
+export type MenuItemInput = Omit<MenuItem, 'id'> & { id?: string };
+
+export interface DataClient {
+  signInWithEmail(email: string, password: string): Promise<User>;
+  signOut(): Promise<void>;
+  getCurrentUser(): Promise<User | null>;
+
+  getMenuItems(vendorId: string): Promise<MenuItem[]>;
+  upsertMenuItem(menuItem: MenuItemInput): Promise<MenuItem>;
+  deleteMenuItem(menuItemId: string): Promise<void>;
+
+  createOrder(order: CreateOrderInput): Promise<Order>;
+  getOrder(orderId: string): Promise<Order | null>;
+  listOrdersForUser(userId: string): Promise<Order[]>;
+  listOrdersForVendor(vendorId: string): Promise<Order[]>;
+  updateOrderStatus(orderId: string, status: OrderStatus): Promise<Order>;
+
+  fetchVendorSettings(vendorId: string): Promise<VendorSettings | null>;
+  fetchRewardActivities(userId: string): Promise<RewardActivity[]>;
+
+  subscribeToOrders(vendorId: string, handler: (order: Order) => void): Subscription;
+  subscribeToMenu(vendorId: string, handler: (menuItem: MenuItem) => void): Subscription;
+}

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -1,0 +1,27 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+
+import { CreateOrderInput, DataClient, MenuItemInput, Subscription } from './dataClient';
+import { createMockDataClient, MockDataClient, MockDataSeed } from './mockData';
+import { Database, SupabaseDataClient } from './supabaseClient';
+
+export * from './models';
+export * from './dataClient';
+export * from './supabaseClient';
+export * from './mockData';
+
+export type DataClientFactoryOptions = {
+  supabase?: SupabaseClient<Database>;
+  useMockData?: boolean;
+  mockSeed?: MockDataSeed;
+};
+
+export const createDataClient = (options: DataClientFactoryOptions = {}): DataClient => {
+  const { supabase, useMockData, mockSeed } = options;
+  if (useMockData || !supabase) {
+    return createMockDataClient(mockSeed);
+  }
+  return new SupabaseDataClient(supabase);
+};
+
+export type { CreateOrderInput, DataClient, Database, MenuItemInput, MockDataSeed, Subscription };
+export { MockDataClient, SupabaseDataClient };

--- a/packages/data/src/mockData.ts
+++ b/packages/data/src/mockData.ts
@@ -1,0 +1,290 @@
+import { CreateOrderInput, DataClient, MenuItemInput, Subscription } from './dataClient';
+import { MenuItem, Order, OrderStatus, RewardActivity, User, VendorSettings } from './models';
+
+export type MockDataSeed = {
+  menuItems?: MenuItem[];
+  orders?: Order[];
+  users?: User[];
+  rewardActivities?: RewardActivity[];
+  vendorSettings?: VendorSettings[];
+};
+
+type Listener<T> = (payload: T) => void;
+
+class Broadcast<T> {
+  private listeners = new Set<Listener<T>>();
+
+  emit(payload: T) {
+    this.listeners.forEach(listener => listener(payload));
+  }
+
+  subscribe(listener: Listener<T>): Subscription {
+    this.listeners.add(listener);
+    return {
+      unsubscribe: () => {
+        this.listeners.delete(listener);
+      }
+    };
+  }
+}
+
+export class MockDataClient implements DataClient {
+  private menuItems: MenuItem[];
+  private orders: Order[];
+  private users: User[];
+  private rewardActivities: RewardActivity[];
+  private vendorSettings: VendorSettings[];
+
+  private menuBroadcasts = new Map<string, Broadcast<MenuItem>>();
+  private orderBroadcasts = new Map<string, Broadcast<Order>>();
+
+  constructor(seed: MockDataSeed = {}) {
+    this.menuItems = [...(seed.menuItems ?? defaultMockMenuItems)];
+    this.orders = [...(seed.orders ?? defaultMockOrders)];
+    this.users = [...(seed.users ?? defaultMockUsers)];
+    this.rewardActivities = [...(seed.rewardActivities ?? defaultMockRewardActivities)];
+    this.vendorSettings = [...(seed.vendorSettings ?? defaultMockVendorSettings)];
+  }
+
+  async signInWithEmail(email: string, _password: string): Promise<User> {
+    const user = this.users.find(candidate => candidate.email === email) ?? this.users[0];
+    return user;
+  }
+
+  async signOut(): Promise<void> {
+    return;
+  }
+
+  async getCurrentUser(): Promise<User | null> {
+    return this.users[0] ?? null;
+  }
+
+  async getMenuItems(vendorId: string): Promise<MenuItem[]> {
+    return this.menuItems.filter(item => item.vendorId === vendorId);
+  }
+
+  async upsertMenuItem(menuItem: MenuItemInput): Promise<MenuItem> {
+    const id = menuItem.id ?? this.createId('menu');
+    const nextItem: MenuItem = { ...menuItem, id };
+    const existingIndex = this.menuItems.findIndex(item => item.id === id);
+    if (existingIndex >= 0) {
+      this.menuItems[existingIndex] = nextItem;
+    } else {
+      this.menuItems.push(nextItem);
+    }
+    this.emitMenu(nextItem.vendorId, nextItem);
+    return nextItem;
+  }
+
+  async deleteMenuItem(menuItemId: string): Promise<void> {
+    const index = this.menuItems.findIndex(item => item.id === menuItemId);
+    if (index >= 0) {
+      const [removed] = this.menuItems.splice(index, 1);
+      this.emitMenu(removed.vendorId, removed);
+    }
+  }
+
+  async createOrder(order: CreateOrderInput): Promise<Order> {
+    const id = order.id ?? this.createId('order');
+    const createdAt = order.createdAt ?? new Date().toISOString();
+    const nextOrder: Order = {
+      ...order,
+      id,
+      createdAt,
+      updatedAt: order.updatedAt ?? createdAt,
+      status: order.status ?? 'pending'
+    };
+    this.orders.push(nextOrder);
+    this.emitOrder(nextOrder.vendorId, nextOrder);
+    return nextOrder;
+  }
+
+  async getOrder(orderId: string): Promise<Order | null> {
+    return this.orders.find(order => order.id === orderId) ?? null;
+  }
+
+  async listOrdersForUser(userId: string): Promise<Order[]> {
+    return this.orders.filter(order => order.userId === userId);
+  }
+
+  async listOrdersForVendor(vendorId: string): Promise<Order[]> {
+    return this.orders.filter(order => order.vendorId === vendorId);
+  }
+
+  async updateOrderStatus(orderId: string, status: OrderStatus): Promise<Order> {
+    const order = this.orders.find(candidate => candidate.id === orderId);
+    if (!order) throw new Error(`Order ${orderId} not found`);
+    const nextOrder = { ...order, status, updatedAt: new Date().toISOString() };
+    const index = this.orders.findIndex(candidate => candidate.id === orderId);
+    this.orders[index] = nextOrder;
+    this.emitOrder(nextOrder.vendorId, nextOrder);
+    return nextOrder;
+  }
+
+  async fetchVendorSettings(vendorId: string): Promise<VendorSettings | null> {
+    return this.vendorSettings.find(settings => settings.vendorId === vendorId) ?? null;
+  }
+
+  async fetchRewardActivities(userId: string): Promise<RewardActivity[]> {
+    return this.rewardActivities.filter(activity => activity.userId === userId);
+  }
+
+  subscribeToOrders(vendorId: string, handler: (order: Order) => void): Subscription {
+    return this.getOrderBroadcast(vendorId).subscribe(handler);
+  }
+
+  subscribeToMenu(vendorId: string, handler: (menuItem: MenuItem) => void): Subscription {
+    return this.getMenuBroadcast(vendorId).subscribe(handler);
+  }
+
+  private createId(prefix: string) {
+    return `${prefix}_${Math.random().toString(16).slice(2)}`;
+  }
+
+  private getMenuBroadcast(vendorId: string) {
+    const existing = this.menuBroadcasts.get(vendorId);
+    if (existing) return existing;
+    const next = new Broadcast<MenuItem>();
+    this.menuBroadcasts.set(vendorId, next);
+    return next;
+  }
+
+  private getOrderBroadcast(vendorId: string) {
+    const existing = this.orderBroadcasts.get(vendorId);
+    if (existing) return existing;
+    const next = new Broadcast<Order>();
+    this.orderBroadcasts.set(vendorId, next);
+    return next;
+  }
+
+  private emitMenu(vendorId: string, menuItem: MenuItem) {
+    this.getMenuBroadcast(vendorId).emit(menuItem);
+  }
+
+  private emitOrder(vendorId: string, order: Order) {
+    this.getOrderBroadcast(vendorId).emit(order);
+  }
+}
+
+export const defaultMockMenuItems: MenuItem[] = [
+  {
+    id: 'menu_espresso',
+    vendorId: 'vendor_cafe',
+    name: 'Espresso',
+    description: 'Rich espresso shot with caramel notes',
+    price: 325,
+    currency: 'USD',
+    isAvailable: true,
+    category: 'Coffee',
+    tags: ['hot', 'caffeine']
+  },
+  {
+    id: 'menu_croissant',
+    vendorId: 'vendor_cafe',
+    name: 'Butter Croissant',
+    description: 'Flaky pastry baked fresh daily',
+    price: 450,
+    currency: 'USD',
+    isAvailable: true,
+    category: 'Bakery',
+    tags: ['vegetarian']
+  },
+  {
+    id: 'menu_sandwich',
+    vendorId: 'vendor_foodtruck',
+    name: 'Chipotle Chicken Sandwich',
+    description: 'Grilled chicken, chipotle mayo, and pickled onions',
+    price: 1099,
+    currency: 'USD',
+    isAvailable: true,
+    category: 'Entrees',
+    tags: ['spicy']
+  }
+];
+
+export const defaultMockOrders: Order[] = [
+  {
+    id: 'order_one',
+    vendorId: 'vendor_cafe',
+    userId: 'user_jane',
+    items: [
+      { menuItemId: 'menu_espresso', quantity: 2, price: 325 },
+      { menuItemId: 'menu_croissant', quantity: 1, price: 450 }
+    ],
+    status: 'ready',
+    total: 1100,
+    createdAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+    updatedAt: new Date(Date.now() - 1000 * 60 * 10).toISOString(),
+    etaMinutes: 5
+  },
+  {
+    id: 'order_two',
+    vendorId: 'vendor_foodtruck',
+    userId: 'user_alex',
+    items: [{ menuItemId: 'menu_sandwich', quantity: 1, price: 1099 }],
+    status: 'preparing',
+    total: 1099,
+    createdAt: new Date(Date.now() - 1000 * 60 * 5).toISOString()
+  }
+];
+
+export const defaultMockUsers: User[] = [
+  {
+    id: 'user_jane',
+    email: 'jane@example.com',
+    displayName: 'Jane Doe',
+    role: 'customer',
+    loyaltyPoints: 120
+  },
+  {
+    id: 'user_alex',
+    email: 'alex@example.com',
+    displayName: 'Alex Taylor',
+    role: 'vendor',
+    preferredVendorId: 'vendor_foodtruck'
+  }
+];
+
+export const defaultMockRewardActivities: RewardActivity[] = [
+  {
+    id: 'reward1',
+    userId: 'user_jane',
+    vendorId: 'vendor_cafe',
+    points: 50,
+    type: 'earn',
+    description: 'Morning order bonus',
+    occurredAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+    orderId: 'order_one'
+  },
+  {
+    id: 'reward2',
+    userId: 'user_jane',
+    vendorId: 'vendor_cafe',
+    points: -20,
+    type: 'redeem',
+    description: 'Free extra shot redemption',
+    occurredAt: new Date(Date.now() - 1000 * 60 * 60 * 12).toISOString()
+  }
+];
+
+export const defaultMockVendorSettings: VendorSettings[] = [
+  {
+    vendorId: 'vendor_cafe',
+    currency: 'USD',
+    timezone: 'America/Los_Angeles',
+    enableLoyalty: true,
+    loyaltyEarnRate: 0.05,
+    loyaltyRedeemRate: 0.01,
+    defaultPrepMinutes: 7
+  },
+  {
+    vendorId: 'vendor_foodtruck',
+    currency: 'USD',
+    timezone: 'America/New_York',
+    enableLoyalty: false,
+    allowScheduledOrders: false,
+    defaultPrepMinutes: 12
+  }
+];
+
+export const createMockDataClient = (seed?: MockDataSeed) => new MockDataClient(seed);

--- a/packages/data/src/models.ts
+++ b/packages/data/src/models.ts
@@ -1,0 +1,81 @@
+export type UserRole = 'guest' | 'customer' | 'vendor' | 'admin';
+
+export type MenuItemOption = {
+  id: string;
+  name: string;
+  priceDelta?: number;
+  isDefault?: boolean;
+};
+
+export type MenuItem = {
+  id: string;
+  vendorId: string;
+  name: string;
+  description?: string;
+  price: number;
+  currency?: string;
+  category?: string;
+  tags?: string[];
+  imageUrl?: string;
+  isAvailable: boolean;
+  options?: MenuItemOption[];
+};
+
+export type OrderStatus = 'draft' | 'pending' | 'preparing' | 'ready' | 'completed' | 'cancelled';
+
+export type OrderItem = {
+  menuItemId: string;
+  quantity: number;
+  price: number;
+  notes?: string;
+  selectedOptionIds?: string[];
+};
+
+export type Order = {
+  id: string;
+  vendorId: string;
+  userId: string;
+  items: OrderItem[];
+  status: OrderStatus;
+  total: number;
+  createdAt: string;
+  updatedAt?: string;
+  etaMinutes?: number;
+  note?: string;
+};
+
+export type User = {
+  id: string;
+  email: string;
+  role: UserRole;
+  displayName?: string;
+  phoneNumber?: string;
+  photoUrl?: string;
+  loyaltyPoints?: number;
+  preferredVendorId?: string;
+};
+
+export type RewardActivityType = 'earn' | 'redeem';
+
+export type RewardActivity = {
+  id: string;
+  userId: string;
+  vendorId: string;
+  points: number;
+  type: RewardActivityType;
+  description?: string;
+  occurredAt: string;
+  orderId?: string;
+};
+
+export type VendorSettings = {
+  vendorId: string;
+  currency: string;
+  timezone?: string;
+  enableLoyalty: boolean;
+  loyaltyEarnRate?: number;
+  loyaltyRedeemRate?: number;
+  allowScheduledOrders?: boolean;
+  defaultPrepMinutes?: number;
+  menuVersion?: string;
+};

--- a/packages/data/src/supabaseClient.ts
+++ b/packages/data/src/supabaseClient.ts
@@ -1,0 +1,403 @@
+import { RealtimeChannel, SupabaseClient, User as SupabaseAuthUser } from '@supabase/supabase-js';
+
+import { CreateOrderInput, DataClient, MenuItemInput, Subscription } from './dataClient';
+import {
+  MenuItem,
+  MenuItemOption,
+  Order,
+  OrderItem,
+  OrderStatus,
+  RewardActivity,
+  User,
+  VendorSettings
+} from './models';
+
+export type Database = {
+  public: {
+    Tables: {
+      menu_items: {
+        Row: {
+          id: string;
+          vendor_id: string;
+          name: string;
+          description: string | null;
+          price: number;
+          currency: string | null;
+          category: string | null;
+          tags: string[] | null;
+          image_url: string | null;
+          is_available: boolean;
+          options: MenuItemOption[] | null;
+          created_at: string;
+          updated_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          vendor_id: string;
+          name: string;
+          description?: string | null;
+          price: number;
+          currency?: string | null;
+          category?: string | null;
+          tags?: string[] | null;
+          image_url?: string | null;
+          is_available: boolean;
+          options?: MenuItemOption[] | null;
+          created_at?: string;
+          updated_at?: string | null;
+        };
+        Update: Partial<Database['public']['Tables']['menu_items']['Insert']>;
+      };
+      orders: {
+        Row: {
+          id: string;
+          vendor_id: string;
+          user_id: string;
+          items: OrderItem[];
+          status: OrderStatus;
+          total: number;
+          created_at: string;
+          updated_at: string | null;
+          eta_minutes: number | null;
+          note: string | null;
+        };
+        Insert: {
+          id?: string;
+          vendor_id: string;
+          user_id: string;
+          items: OrderItem[];
+          status?: OrderStatus;
+          total: number;
+          created_at?: string;
+          updated_at?: string | null;
+          eta_minutes?: number | null;
+          note?: string | null;
+        };
+        Update: Partial<Database['public']['Tables']['orders']['Insert']>;
+      };
+      reward_activities: {
+        Row: {
+          id: string;
+          user_id: string;
+          vendor_id: string;
+          points: number;
+          type: 'earn' | 'redeem';
+          description: string | null;
+          occurred_at: string;
+          order_id: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          vendor_id: string;
+          points: number;
+          type: 'earn' | 'redeem';
+          description?: string | null;
+          occurred_at?: string;
+          order_id?: string | null;
+        };
+        Update: Partial<Database['public']['Tables']['reward_activities']['Insert']>;
+      };
+      users: {
+        Row: {
+          id: string;
+          email: string;
+          role: string;
+          display_name: string | null;
+          phone_number: string | null;
+          photo_url: string | null;
+          loyalty_points: number | null;
+          preferred_vendor_id: string | null;
+        };
+        Insert: {
+          id?: string;
+          email: string;
+          role: string;
+          display_name?: string | null;
+          phone_number?: string | null;
+          photo_url?: string | null;
+          loyalty_points?: number | null;
+          preferred_vendor_id?: string | null;
+        };
+        Update: Partial<Database['public']['Tables']['users']['Insert']>;
+      };
+      vendor_settings: {
+        Row: {
+          vendor_id: string;
+          currency: string;
+          timezone: string | null;
+          enable_loyalty: boolean;
+          loyalty_earn_rate: number | null;
+          loyalty_redeem_rate: number | null;
+          allow_scheduled_orders: boolean | null;
+          default_prep_minutes: number | null;
+          menu_version: string | null;
+        };
+        Insert: {
+          vendor_id: string;
+          currency: string;
+          timezone?: string | null;
+          enable_loyalty?: boolean;
+          loyalty_earn_rate?: number | null;
+          loyalty_redeem_rate?: number | null;
+          allow_scheduled_orders?: boolean | null;
+          default_prep_minutes?: number | null;
+          menu_version?: string | null;
+        };
+        Update: Partial<Database['public']['Tables']['vendor_settings']['Insert']>;
+      };
+    };
+    Views: never;
+    Functions: never;
+    Enums: never;
+    CompositeTypes: never;
+  };
+};
+
+export class SupabaseDataClient implements DataClient {
+  constructor(private readonly client: SupabaseClient<Database>) {}
+
+  async signInWithEmail(email: string, password: string): Promise<User> {
+    const { data, error } = await this.client.auth.signInWithPassword({ email, password });
+    if (error) throw error;
+    const authUser = data.user;
+    if (!authUser) throw new Error('User could not be loaded after sign-in');
+    return mapAuthUser(authUser);
+  }
+
+  async signOut(): Promise<void> {
+    const { error } = await this.client.auth.signOut();
+    if (error) throw error;
+  }
+
+  async getCurrentUser(): Promise<User | null> {
+    const { data, error } = await this.client.auth.getUser();
+    if (error) throw error;
+    return mapAuthUser(data.user ?? null);
+  }
+
+  async getMenuItems(vendorId: string): Promise<MenuItem[]> {
+    const { data, error } = await this.client.from('menu_items').select('*').eq('vendor_id', vendorId);
+    if (error) throw error;
+    return (data ?? []).map(mapMenuItemFromRow);
+  }
+
+  async upsertMenuItem(menuItem: MenuItemInput): Promise<MenuItem> {
+    const { data, error } = await this.client
+      .from('menu_items')
+      .upsert(toMenuItemInsert(menuItem))
+      .select()
+      .single();
+    if (error) throw error;
+    return mapMenuItemFromRow(data);
+  }
+
+  async deleteMenuItem(menuItemId: string): Promise<void> {
+    const { error } = await this.client.from('menu_items').delete().eq('id', menuItemId);
+    if (error) throw error;
+  }
+
+  async createOrder(order: CreateOrderInput): Promise<Order> {
+    const { data, error } = await this.client
+      .from('orders')
+      .insert(toOrderInsert(order))
+      .select()
+      .single();
+    if (error) throw error;
+    return mapOrderFromRow(data);
+  }
+
+  async getOrder(orderId: string): Promise<Order | null> {
+    const { data, error } = await this.client.from('orders').select('*').eq('id', orderId).single();
+    if (error) {
+      if (error.code === 'PGRST116') return null; // row not found
+      throw error;
+    }
+    return data ? mapOrderFromRow(data) : null;
+  }
+
+  async listOrdersForUser(userId: string): Promise<Order[]> {
+    const { data, error } = await this.client
+      .from('orders')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false });
+    if (error) throw error;
+    return (data ?? []).map(mapOrderFromRow);
+  }
+
+  async listOrdersForVendor(vendorId: string): Promise<Order[]> {
+    const { data, error } = await this.client
+      .from('orders')
+      .select('*')
+      .eq('vendor_id', vendorId)
+      .order('created_at', { ascending: false });
+    if (error) throw error;
+    return (data ?? []).map(mapOrderFromRow);
+  }
+
+  async updateOrderStatus(orderId: string, status: OrderStatus): Promise<Order> {
+    const { data, error } = await this.client
+      .from('orders')
+      .update({ status, updated_at: new Date().toISOString() })
+      .eq('id', orderId)
+      .select()
+      .single();
+    if (error) throw error;
+    return mapOrderFromRow(data);
+  }
+
+  async fetchVendorSettings(vendorId: string): Promise<VendorSettings | null> {
+    const { data, error } = await this.client.from('vendor_settings').select('*').eq('vendor_id', vendorId).single();
+    if (error) {
+      if (error.code === 'PGRST116') return null;
+      throw error;
+    }
+    return data ? mapVendorSettingsFromRow(data) : null;
+  }
+
+  async fetchRewardActivities(userId: string): Promise<RewardActivity[]> {
+    const { data, error } = await this.client
+      .from('reward_activities')
+      .select('*')
+      .eq('user_id', userId)
+      .order('occurred_at', { ascending: false });
+    if (error) throw error;
+    return (data ?? []).map(mapRewardActivityFromRow);
+  }
+
+  subscribeToOrders(vendorId: string, handler: (order: Order) => void): Subscription {
+    const channel = this.client
+      .channel(`orders:${vendorId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'orders', filter: `vendor_id=eq.${vendorId}` },
+        payload => {
+          if (payload.new) {
+            handler(mapOrderFromRow(payload.new as Database['public']['Tables']['orders']['Row']));
+          }
+        }
+      )
+      .subscribe();
+    return wrapRealtimeChannel(channel);
+  }
+
+  subscribeToMenu(vendorId: string, handler: (menuItem: MenuItem) => void): Subscription {
+    const channel = this.client
+      .channel(`menu:${vendorId}`)
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'menu_items', filter: `vendor_id=eq.${vendorId}` },
+        payload => {
+          if (payload.new) {
+            handler(mapMenuItemFromRow(payload.new as Database['public']['Tables']['menu_items']['Row']));
+          }
+        }
+      )
+      .subscribe();
+    return wrapRealtimeChannel(channel);
+  }
+}
+
+const wrapRealtimeChannel = (channel: RealtimeChannel): Subscription => ({
+  unsubscribe: () => channel.unsubscribe()
+});
+
+const mapAuthUser = (authUser: SupabaseAuthUser | null): User | null => {
+  if (!authUser) return null;
+  const metadata = authUser.user_metadata ?? {};
+  return {
+    id: authUser.id,
+    email: authUser.email ?? '',
+    role: (metadata.role as User['role']) ?? 'customer',
+    displayName: (metadata.displayName as string | undefined) ?? (metadata.full_name as string | undefined),
+    phoneNumber: (metadata.phone_number as string | undefined) ?? undefined,
+    photoUrl: (metadata.avatar_url as string | undefined) ?? undefined,
+    loyaltyPoints: (metadata.loyaltyPoints as number | undefined) ?? undefined,
+    preferredVendorId: (metadata.preferredVendorId as string | undefined) ?? undefined
+  };
+};
+
+const mapMenuItemFromRow = (row: Database['public']['Tables']['menu_items']['Row']): MenuItem => ({
+  id: row.id,
+  vendorId: row.vendor_id,
+  name: row.name,
+  description: row.description ?? undefined,
+  price: row.price,
+  currency: row.currency ?? undefined,
+  category: row.category ?? undefined,
+  tags: row.tags ?? undefined,
+  imageUrl: row.image_url ?? undefined,
+  isAvailable: row.is_available,
+  options: row.options ?? undefined
+});
+
+const toMenuItemInsert = (
+  menuItem: MenuItemInput
+): Database['public']['Tables']['menu_items']['Insert'] => ({
+  id: menuItem.id,
+  vendor_id: menuItem.vendorId,
+  name: menuItem.name,
+  description: menuItem.description ?? null,
+  price: menuItem.price,
+  currency: menuItem.currency ?? null,
+  category: menuItem.category ?? null,
+  tags: menuItem.tags ?? null,
+  image_url: menuItem.imageUrl ?? null,
+  is_available: menuItem.isAvailable,
+  options: menuItem.options ?? null,
+  updated_at: new Date().toISOString()
+});
+
+const mapOrderFromRow = (row: Database['public']['Tables']['orders']['Row']): Order => ({
+  id: row.id,
+  vendorId: row.vendor_id,
+  userId: row.user_id,
+  items: row.items,
+  status: row.status,
+  total: row.total,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at ?? undefined,
+  etaMinutes: row.eta_minutes ?? undefined,
+  note: row.note ?? undefined
+});
+
+const toOrderInsert = (order: CreateOrderInput): Database['public']['Tables']['orders']['Insert'] => ({
+  id: order.id,
+  vendor_id: order.vendorId,
+  user_id: order.userId,
+  items: order.items,
+  status: order.status ?? 'pending',
+  total: order.total,
+  created_at: order.createdAt ?? new Date().toISOString(),
+  updated_at: order.updatedAt ?? null,
+  eta_minutes: order.etaMinutes ?? null,
+  note: order.note ?? null
+});
+
+const mapRewardActivityFromRow = (
+  row: Database['public']['Tables']['reward_activities']['Row']
+): RewardActivity => ({
+  id: row.id,
+  userId: row.user_id,
+  vendorId: row.vendor_id,
+  points: row.points,
+  type: row.type,
+  description: row.description ?? undefined,
+  occurredAt: row.occurred_at,
+  orderId: row.order_id ?? undefined
+});
+
+const mapVendorSettingsFromRow = (
+  row: Database['public']['Tables']['vendor_settings']['Row']
+): VendorSettings => ({
+  vendorId: row.vendor_id,
+  currency: row.currency,
+  timezone: row.timezone ?? undefined,
+  enableLoyalty: row.enable_loyalty,
+  loyaltyEarnRate: row.loyalty_earn_rate ?? undefined,
+  loyaltyRedeemRate: row.loyalty_redeem_rate ?? undefined,
+  allowScheduledOrders: row.allow_scheduled_orders ?? undefined,
+  defaultPrepMinutes: row.default_prep_minutes ?? undefined,
+  menuVersion: row.menu_version ?? undefined
+});

--- a/packages/data/tsconfig.json
+++ b/packages/data/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,9 @@
       "@countrtop/models": ["packages/models/src"],
       "@countrtop/models/*": ["packages/models/src/*"],
       "@countrtop/api-client": ["packages/api-client/src"],
-      "@countrtop/api-client/*": ["packages/api-client/src/*"]
+      "@countrtop/api-client/*": ["packages/api-client/src/*"],
+      "@countrtop/data": ["packages/data/src"],
+      "@countrtop/data/*": ["packages/data/src/*"]
     }
   },
   "include": ["packages", "apps"],


### PR DESCRIPTION
## Summary
- add a shared data package with typed domain models for menu items, orders, users, reward activity, and vendor settings
- provide a Supabase-backed data client for auth, CRUD, and realtime subscriptions
- include mock data utilities and a client factory for local development fallbacks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694234074680832f9dbf87338294a978)