### PR TITLE
Add payments and loyalty workflows

### DIFF
--- a/apps/dashboard/lib/payments.ts
+++ b/apps/dashboard/lib/payments.ts
@@ -1,0 +1,21 @@
+import {
+  CheckoutIntentPayload,
+  CheckoutIntentResponse,
+  initiateCheckout,
+  recordRewardActivity,
+  RewardActivityRequest
+} from '@countrtop/api-client';
+
+type ApiClientConfig = {
+  baseUrl?: string;
+};
+
+export const startCheckout = async (
+  payload: CheckoutIntentPayload,
+  config?: ApiClientConfig
+): Promise<CheckoutIntentResponse> => initiateCheckout(payload, config);
+
+export const logRewardActivity = async (
+  payload: RewardActivityRequest,
+  config?: ApiClientConfig
+) => recordRewardActivity(payload, config);

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@countrtop/api-client": "workspace:*",
+    "@countrtop/functions": "workspace:*",
     "@countrtop/models": "workspace:*",
     "@countrtop/ui": "workspace:*",
     "next": "14.2.6",

--- a/apps/dashboard/pages/api/loyalty/activities.ts
+++ b/apps/dashboard/pages/api/loyalty/activities.ts
@@ -1,0 +1,48 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { createDataClient, RewardActivityInput } from '@countrtop/data';
+import { LoyaltyService } from '@countrtop/functions';
+
+type LoyaltyResponse =
+  | { ok: true; balance: number; activityId: string }
+  | { ok: false; error: string };
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<LoyaltyResponse>) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ ok: false, error: 'Method not allowed' });
+  }
+
+  const body = req.body as RewardActivityInput;
+  if (!body?.userId || !body.vendorId || typeof body.points !== 'number' || !body.type) {
+    return res.status(400).json({ ok: false, error: 'Missing required fields' });
+  }
+
+  const dataClient = createDataClient({ useMockData: true });
+  const loyalty = new LoyaltyService(dataClient);
+
+  try {
+    const result =
+      body.type === 'redeem'
+        ? await loyalty.redeemForOrder({
+            userId: body.userId,
+            vendorId: body.vendorId,
+            orderId: body.orderId,
+            description: body.description,
+            points: Math.abs(body.points)
+          })
+        : await loyalty.accrueForOrder({
+            userId: body.userId,
+            vendorId: body.vendorId,
+            orderId: body.orderId,
+            description: body.description,
+            total: body.points,
+            punches: 0,
+            overridePoints: body.points
+          });
+
+    return res.status(200).json({ ok: true, balance: result.balance, activityId: result.activity.id });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to record loyalty activity';
+    return res.status(500).json({ ok: false, error: message });
+  }
+}

--- a/apps/dashboard/pages/api/payments/checkout.ts
+++ b/apps/dashboard/pages/api/payments/checkout.ts
@@ -1,0 +1,83 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { PaymentService } from '@countrtop/functions';
+
+type CheckoutRequestBody = {
+  amount: number;
+  currency?: string;
+  orderId?: string;
+  userId?: string;
+  vendorId?: string;
+  customerId?: string;
+  description?: string;
+  successUrl?: string;
+  cancelUrl?: string;
+  mode?: 'payment' | 'setup';
+};
+
+type CheckoutResponse =
+  | {
+      ok: true;
+      paymentIntentId?: string;
+      clientSecret?: string;
+      checkoutSessionId?: string;
+      checkoutUrl?: string | null;
+    }
+  | { ok: false; error: string };
+
+const resolveUrl = (value: string | undefined, fallbackEnv: string | undefined, defaultValue: string) =>
+  value ?? fallbackEnv ?? defaultValue;
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<CheckoutResponse>) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ ok: false, error: 'Method not allowed' });
+  }
+
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    return res.status(500).json({ ok: false, error: 'Stripe secret key not configured' });
+  }
+
+  const body = req.body as CheckoutRequestBody;
+  if (typeof body?.amount !== 'number') {
+    return res.status(400).json({ ok: false, error: 'amount is required' });
+  }
+
+  const service = new PaymentService({ secretKey, defaultCurrency: body.currency ?? 'usd' });
+
+  try {
+    const paymentIntent = await service.createPaymentIntent({
+      amount: body.amount,
+      currency: body.currency,
+      orderId: body.orderId,
+      userId: body.userId,
+      vendorId: body.vendorId,
+      customerId: body.customerId,
+      description: body.description
+    });
+
+    const checkoutSession = await service.createCheckoutSession({
+      amount: body.amount,
+      currency: body.currency,
+      orderId: body.orderId,
+      userId: body.userId,
+      vendorId: body.vendorId,
+      customerId: body.customerId,
+      description: body.description,
+      mode: body.mode,
+      successUrl: resolveUrl(body.successUrl, process.env.CHECKOUT_SUCCESS_URL, 'https://countrtop.app/success'),
+      cancelUrl: resolveUrl(body.cancelUrl, process.env.CHECKOUT_CANCEL_URL, 'https://countrtop.app/cancel')
+    });
+
+    return res.status(200).json({
+      ok: true,
+      paymentIntentId: paymentIntent.paymentIntentId,
+      clientSecret: paymentIntent.clientSecret,
+      checkoutSessionId: checkoutSession.sessionId,
+      checkoutUrl: checkoutSession.url
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected payment error';
+    return res.status(500).json({ ok: false, error: message });
+  }
+}

--- a/apps/dashboard/pages/api/payments/webhook.ts
+++ b/apps/dashboard/pages/api/payments/webhook.ts
@@ -1,0 +1,66 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import Stripe from 'stripe';
+
+import { createDataClient } from '@countrtop/data';
+import { LoyaltyService, StripeWebhookHandler } from '@countrtop/functions';
+
+export const config = {
+  api: {
+    bodyParser: false
+  }
+};
+
+const API_VERSION: Stripe.LatestApiVersion = '2024-06-20';
+
+const bufferRequest = (req: NextApiRequest): Promise<Buffer> =>
+  new Promise((resolve, reject) => {
+    const chunks: Uint8Array[] = [];
+
+    req.on('data', chunk => chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks)));
+    req.on('error', reject);
+  });
+
+type WebhookResponse = {
+  acknowledged: boolean;
+  type: 'payment_succeeded' | 'payment_failed' | 'ignored';
+  orderId?: string;
+  paymentIntentId?: string;
+  reason?: string;
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<WebhookResponse>) {
+  if (req.method !== 'POST') {
+    return res.status(405).end('Method not allowed');
+  }
+
+  const stripeSignature = req.headers['stripe-signature'];
+  if (!stripeSignature || Array.isArray(stripeSignature)) {
+    return res.status(400).json({ acknowledged: false, type: 'ignored', reason: 'Missing signature' });
+  }
+
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!secretKey || !webhookSecret) {
+    return res.status(500).json({
+      acknowledged: false,
+      type: 'ignored',
+      reason: 'Stripe credentials are not configured'
+    });
+  }
+
+  const stripe = new Stripe(secretKey, { apiVersion: API_VERSION });
+  const dataClient = createDataClient({ useMockData: true });
+  const loyalty = new LoyaltyService(dataClient);
+  const webhook = new StripeWebhookHandler(stripe, loyalty);
+
+  try {
+    const payload = await bufferRequest(req);
+    const result = await webhook.handleEvent(payload, stripeSignature, webhookSecret);
+    const statusCode = result.type === 'ignored' ? 200 : 202;
+    return res.status(statusCode).json(result);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : 'Unknown webhook error';
+    return res.status(400).json({ acknowledged: false, type: 'ignored', reason });
+  }
+}

--- a/apps/mobile/services/payments.ts
+++ b/apps/mobile/services/payments.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from 'react';
+
+import {
+  CheckoutIntentPayload,
+  initiateCheckout,
+  recordRewardActivity,
+  RewardActivityRequest
+} from '@countrtop/api-client';
+
+type ApiClientConfig = {
+  baseUrl?: string;
+};
+
+export const useCheckoutService = (config?: ApiClientConfig) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const startCheckout = useCallback(
+    async (payload: CheckoutIntentPayload) => {
+      setLoading(true);
+      setError(null);
+
+      const result = await initiateCheckout(payload, config);
+      if (!result.ok) {
+        setError(result.error ?? 'Unable to start checkout');
+      }
+
+      setLoading(false);
+      return result;
+    },
+    [config]
+  );
+
+  return { startCheckout, loading, error };
+};
+
+export const useRewardActivityService = (config?: ApiClientConfig) => {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const recordActivity = useCallback(
+    async (payload: RewardActivityRequest) => {
+      setSaving(true);
+      setError(null);
+      const result = await recordRewardActivity(payload, config);
+      if (!result.ok) {
+        setError(result.error ?? 'Unable to record reward activity');
+      }
+      setSaving(false);
+      return result;
+    },
+    [config]
+  );
+
+  return { recordActivity, saving, error };
+};

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -50,3 +50,70 @@ export const fetchRecentOrders = async (
   if (!response.ok) throw new Error('Failed to load orders');
   return response.json();
 };
+
+export type CheckoutIntentPayload = {
+  amount: number;
+  currency?: string;
+  orderId?: string;
+  userId?: string;
+  vendorId?: string;
+  customerId?: string;
+  description?: string;
+  successUrl?: string;
+  cancelUrl?: string;
+  mode?: 'payment' | 'setup';
+};
+
+export type CheckoutIntentResponse = {
+  ok: boolean;
+  paymentIntentId?: string;
+  clientSecret?: string;
+  checkoutSessionId?: string;
+  checkoutUrl?: string | null;
+  error?: string;
+};
+
+export type RewardActivityRequest = {
+  userId: string;
+  vendorId: string;
+  points: number;
+  type: 'earn' | 'redeem';
+  description?: string;
+  orderId?: string;
+};
+
+export const initiateCheckout = async (
+  payload: CheckoutIntentPayload,
+  config: ApiConfig = defaultConfig
+): Promise<CheckoutIntentResponse> => {
+  const response = await fetch(createUrl('/payments/checkout', config.baseUrl ?? defaultConfig.baseUrl), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => ({}));
+    return { ok: false, error: errorBody.error ?? 'Unable to start checkout' };
+  }
+
+  return response.json();
+};
+
+export const recordRewardActivity = async (
+  payload: RewardActivityRequest,
+  config: ApiConfig = defaultConfig
+): Promise<{ ok: boolean; error?: string }> => {
+  const response = await fetch(createUrl('/loyalty/activities', config.baseUrl ?? defaultConfig.baseUrl), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => ({}));
+    return { ok: false, error: errorBody.error ?? 'Failed to record loyalty activity' };
+  }
+
+  return response.json();
+};

--- a/packages/data/src/dataClient.ts
+++ b/packages/data/src/dataClient.ts
@@ -1,4 +1,12 @@
-import { MenuItem, Order, OrderStatus, RewardActivity, User, VendorSettings } from './models';
+import {
+  MenuItem,
+  Order,
+  OrderStatus,
+  RewardActivity,
+  RewardActivityInput,
+  User,
+  VendorSettings
+} from './models';
 
 export type Subscription = {
   unsubscribe: () => Promise<void> | void;
@@ -26,6 +34,8 @@ export interface DataClient {
 
   fetchVendorSettings(vendorId: string): Promise<VendorSettings | null>;
   fetchRewardActivities(userId: string): Promise<RewardActivity[]>;
+  recordRewardActivity(activity: RewardActivityInput): Promise<RewardActivity>;
+  adjustUserLoyaltyPoints(userId: string, delta: number): Promise<number>;
 
   subscribeToOrders(vendorId: string, handler: (order: Order) => void): Subscription;
   subscribeToMenu(vendorId: string, handler: (menuItem: MenuItem) => void): Subscription;

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -24,5 +24,13 @@ export const createDataClient = (options: DataClientFactoryOptions = {}): DataCl
   return new SupabaseDataClient(supabase);
 };
 
-export type { CreateOrderInput, DataClient, Database, MenuItemInput, MockDataSeed, Subscription };
+export type {
+  CreateOrderInput,
+  DataClient,
+  Database,
+  MenuItemInput,
+  MockDataSeed,
+  RewardActivityInput,
+  Subscription
+};
 export { MockDataClient, SupabaseDataClient };

--- a/packages/data/src/models.ts
+++ b/packages/data/src/models.ts
@@ -68,6 +68,17 @@ export type RewardActivity = {
   orderId?: string;
 };
 
+export type RewardActivityInput = {
+  id?: string;
+  userId: string;
+  vendorId: string;
+  points: number;
+  type: RewardActivityType;
+  description?: string;
+  occurredAt?: string;
+  orderId?: string;
+};
+
 export type VendorSettings = {
   vendorId: string;
   currency: string;

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@countrtop/functions",
+  "version": "0.1.0",
+  "private": false,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "source": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --emitDeclarationOnly",
+    "lint": "eslint 'src/**/*.{ts,tsx}'"
+  },
+  "dependencies": {
+    "@countrtop/data": "workspace:*",
+    "stripe": "^17.0.0"
+  }
+}

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -1,0 +1,3 @@
+export * from './payments';
+export * from './loyalty';
+export * from './webhooks';

--- a/packages/functions/src/loyalty.ts
+++ b/packages/functions/src/loyalty.ts
@@ -1,0 +1,93 @@
+import {
+  DataClient,
+  RewardActivity,
+  RewardActivityInput,
+  VendorSettings
+} from '@countrtop/data';
+
+export type LoyaltyConfig = {
+  defaultEarnRate?: number;
+  defaultRedeemRate?: number;
+  punchValue?: number;
+};
+
+export type AccrualRequest = {
+  userId: string;
+  vendorId: string;
+  orderId?: string;
+  total: number;
+  vendorSettings?: VendorSettings | null;
+  description?: string;
+  punches?: number;
+  overridePoints?: number;
+};
+
+export type RedemptionRequest = {
+  userId: string;
+  vendorId: string;
+  orderId?: string;
+  points: number;
+  description?: string;
+};
+
+export type LoyaltyResult = {
+  balance: number;
+  activity: RewardActivity;
+};
+
+const defaultConfig: Required<LoyaltyConfig> = {
+  defaultEarnRate: 0.05,
+  defaultRedeemRate: 0.01,
+  punchValue: 10
+};
+
+export class LoyaltyService {
+  private readonly config: Required<LoyaltyConfig>;
+
+  constructor(private readonly dataClient: DataClient, config: LoyaltyConfig = {}) {
+    this.config = { ...defaultConfig, ...config };
+  }
+
+  accrueForOrder = async (request: AccrualRequest): Promise<LoyaltyResult> => {
+    const earnRate = request.vendorSettings?.loyaltyEarnRate ?? this.config.defaultEarnRate;
+    const punchPoints = (request.punches ?? 0) * this.config.punchValue;
+    const calculatedPoints = Math.floor(request.total * earnRate) + punchPoints;
+    const earned = Math.max(0, request.overridePoints ?? calculatedPoints);
+
+    const activityInput: RewardActivityInput = {
+      userId: request.userId,
+      vendorId: request.vendorId,
+      points: earned,
+      type: 'earn',
+      description: request.description ?? 'Loyalty accrual from order payment',
+      occurredAt: new Date().toISOString(),
+      orderId: request.orderId
+    };
+
+    const activity = await this.dataClient.recordRewardActivity(activityInput);
+    const balance = await this.dataClient.adjustUserLoyaltyPoints(request.userId, earned);
+    return { balance, activity };
+  };
+
+  redeemForOrder = async (request: RedemptionRequest): Promise<LoyaltyResult> => {
+    const redeemAmount = Math.abs(request.points);
+    const activityInput: RewardActivityInput = {
+      userId: request.userId,
+      vendorId: request.vendorId,
+      points: -redeemAmount,
+      type: 'redeem',
+      description: request.description ?? 'Redeemed loyalty credit',
+      occurredAt: new Date().toISOString(),
+      orderId: request.orderId
+    };
+
+    const activity = await this.dataClient.recordRewardActivity(activityInput);
+    const balance = await this.dataClient.adjustUserLoyaltyPoints(request.userId, -redeemAmount);
+    return { balance, activity };
+  };
+
+  calculateRedeemableValue(points: number, vendorSettings?: VendorSettings | null): number {
+    const redeemRate = vendorSettings?.loyaltyRedeemRate ?? this.config.defaultRedeemRate;
+    return Math.max(0, points * redeemRate);
+  }
+}

--- a/packages/functions/src/payments.ts
+++ b/packages/functions/src/payments.ts
@@ -1,0 +1,120 @@
+import Stripe from 'stripe';
+
+export type PaymentServiceConfig = {
+  secretKey: string;
+  defaultCurrency?: string;
+};
+
+export type CheckoutSessionRequest = {
+  amount: number;
+  currency?: string;
+  successUrl: string;
+  cancelUrl: string;
+  orderId?: string;
+  userId?: string;
+  vendorId?: string;
+  customerId?: string;
+  description?: string;
+  metadata?: Record<string, string>;
+  lineItems?: Stripe.Checkout.SessionCreateParams.LineItem[];
+  mode?: Stripe.Checkout.SessionCreateParams.Mode;
+};
+
+export type CheckoutSessionResult = {
+  sessionId: string;
+  url?: string | null;
+  paymentIntentId?: string;
+};
+
+export type PaymentIntentRequest = {
+  amount: number;
+  currency?: string;
+  orderId?: string;
+  userId?: string;
+  vendorId?: string;
+  customerId?: string;
+  description?: string;
+  metadata?: Record<string, string>;
+};
+
+export type PaymentIntentResult = {
+  paymentIntentId: string;
+  clientSecret: string;
+};
+
+const API_VERSION: Stripe.LatestApiVersion = '2024-06-20';
+
+export class PaymentService {
+  private readonly stripe: Stripe;
+  private readonly defaultCurrency: string;
+
+  constructor(config: PaymentServiceConfig) {
+    this.defaultCurrency = config.defaultCurrency ?? 'usd';
+    this.stripe = new Stripe(config.secretKey, { apiVersion: API_VERSION });
+  }
+
+  createPaymentIntent = async (request: PaymentIntentRequest): Promise<PaymentIntentResult> => {
+    const currency = request.currency ?? this.defaultCurrency;
+    const paymentIntent = await this.stripe.paymentIntents.create({
+      amount: Math.round(request.amount),
+      currency,
+      customer: request.customerId,
+      description: request.description,
+      metadata: this.buildMetadata(request)
+    });
+
+    if (!paymentIntent.client_secret) {
+      throw new Error('Stripe did not return a client secret for the PaymentIntent.');
+    }
+
+    return { paymentIntentId: paymentIntent.id, clientSecret: paymentIntent.client_secret };
+  };
+
+  createCheckoutSession = async (request: CheckoutSessionRequest): Promise<CheckoutSessionResult> => {
+    const currency = request.currency ?? this.defaultCurrency;
+    const lineItems = request.lineItems ?? [
+      {
+        price_data: {
+          currency,
+          product_data: { name: request.description ?? 'Order payment' },
+          unit_amount: Math.round(request.amount)
+        },
+        quantity: 1
+      }
+    ];
+
+    const session = await this.stripe.checkout.sessions.create({
+      mode: request.mode ?? 'payment',
+      success_url: request.successUrl,
+      cancel_url: request.cancelUrl,
+      customer: request.customerId,
+      line_items: lineItems,
+      payment_intent_data: { metadata: this.buildMetadata(request) },
+      metadata: this.buildMetadata(request)
+    });
+
+    return {
+      sessionId: session.id,
+      url: session.url,
+      paymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : undefined
+    };
+  };
+
+  get client() {
+    return this.stripe;
+  }
+
+  private buildMetadata(
+    request: Pick<PaymentIntentRequest, 'metadata' | 'orderId' | 'userId' | 'vendorId'>
+  ): Record<string, string> {
+    const baseMetadata: Record<string, string> = {};
+    if (request.orderId) baseMetadata.orderId = request.orderId;
+    if (request.userId) baseMetadata.userId = request.userId;
+    if (request.vendorId) baseMetadata.vendorId = request.vendorId;
+
+    return {
+      ...baseMetadata,
+      ...(request.metadata ?? {})
+    };
+  }
+}

--- a/packages/functions/src/webhooks.ts
+++ b/packages/functions/src/webhooks.ts
@@ -1,0 +1,65 @@
+import Stripe from 'stripe';
+
+import { LoyaltyService } from './loyalty';
+
+export type WebhookHandlerResult = {
+  acknowledged: boolean;
+  type: 'payment_succeeded' | 'payment_failed' | 'ignored';
+  orderId?: string;
+  paymentIntentId?: string;
+  reason?: string;
+};
+
+export class StripeWebhookHandler {
+  constructor(private readonly stripe: Stripe, private readonly loyalty?: LoyaltyService) {}
+
+  handleEvent = async (
+    payload: Buffer | string,
+    signature: string,
+    webhookSecret: string
+  ): Promise<WebhookHandlerResult> => {
+    const event = this.stripe.webhooks.constructEvent(payload, signature, webhookSecret);
+
+    if (event.type === 'payment_intent.succeeded') {
+      const paymentIntent = event.data.object as Stripe.PaymentIntent;
+      await this.handlePaymentSucceeded(paymentIntent);
+      return {
+        acknowledged: true,
+        type: 'payment_succeeded',
+        orderId: paymentIntent.metadata.orderId,
+        paymentIntentId: paymentIntent.id
+      };
+    }
+
+    if (event.type === 'payment_intent.payment_failed') {
+      const paymentIntent = event.data.object as Stripe.PaymentIntent;
+      return {
+        acknowledged: true,
+        type: 'payment_failed',
+        orderId: paymentIntent.metadata.orderId,
+        paymentIntentId: paymentIntent.id,
+        reason: paymentIntent.last_payment_error?.message
+      };
+    }
+
+    return { acknowledged: true, type: 'ignored' };
+  };
+
+  private async handlePaymentSucceeded(paymentIntent: Stripe.PaymentIntent) {
+    if (!this.loyalty) return;
+
+    if (!paymentIntent.metadata?.userId || !paymentIntent.metadata?.vendorId) {
+      return;
+    }
+
+    const totalInDollars = (paymentIntent.amount_received ?? paymentIntent.amount) / 100;
+
+    await this.loyalty.accrueForOrder({
+      orderId: paymentIntent.metadata.orderId,
+      userId: paymentIntent.metadata.userId,
+      vendorId: paymentIntent.metadata.vendorId,
+      total: totalInDollars,
+      description: 'Payment completed via Stripe'
+    });
+  }
+}

--- a/packages/functions/tsconfig.json
+++ b/packages/functions/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,9 @@
       "@countrtop/api-client": ["packages/api-client/src"],
       "@countrtop/api-client/*": ["packages/api-client/src/*"],
       "@countrtop/data": ["packages/data/src"],
-      "@countrtop/data/*": ["packages/data/src/*"]
+      "@countrtop/data/*": ["packages/data/src/*"],
+      "@countrtop/functions": ["packages/functions/src"],
+      "@countrtop/functions/*": ["packages/functions/src/*"]
     }
   },
   "include": ["packages", "apps"],


### PR DESCRIPTION
## Summary
- add a shared functions package for Stripe checkout/session creation, webhook handling, and loyalty accrual/redeem utilities
- extend data client capabilities plus dashboard API routes to record loyalty events and return checkout/payment details
- expose client-side helpers for mobile and dashboard apps to initiate checkout flows and log reward activity

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694239e06d40832fa36961e39a9a4657)